### PR TITLE
WIP: Make operations on named pipes more consistent

### DIFF
--- a/src/bufio.c
+++ b/src/bufio.c
@@ -1398,16 +1398,10 @@ input buffers. If the value of timeout is -1, the poll blocks indefinitely.
       return -1;  // Stream error
     }
 
-    // When trying a non-blocking read on a pipe where the writer hung up, macOS yields 0 bytes and ETIMEDOUT
-    if (stream->type == BUFIO_PIPE && nbytes == 0 && read_errno == ETIMEDOUT) {
-      stream->status = BUFIO_EPIPE;
-      return -1;  // Stream error
-    }
-
-    // When trying a non-blocking read on a TCP connection in CLOSE_WAIT state,
+    // When trying a non-blocking read on a TCP connection in CLOSE_WAIT state or on a pipe where the writer hung up
     // - macOS yields 0 bytes and ETIMEDOUT, while
     // - Linux yields 0 bytes and EAGAIN.
-    if (stream->type == BUFIO_SOCKET && nbytes == 0 && (read_errno == ETIMEDOUT || read_errno == EAGAIN)) {
+    if ((stream->type == BUFIO_PIPE || stream->type == BUFIO_SOCKET) && nbytes == 0 && (read_errno == ETIMEDOUT || read_errno == EAGAIN)) {
       stream->status = BUFIO_EPIPE;
       return -1;  // Stream error
     }

--- a/src/bufio.c
+++ b/src/bufio.c
@@ -721,6 +721,9 @@ application code does not crash during writes to a broken pipe.
       goto close_free_and_out;
     }
 
+    if (stream->type == BUFIO_FIFO || stream->type == BUFIO_PIPE)
+      ignore_sigpipe(stream->fd);
+
     return stream;
   }
 

--- a/src/bufio.c
+++ b/src/bufio.c
@@ -464,7 +464,7 @@ static int accept_socket(bufio_stream *stream, int timeout, const char* info)
     ignore_sigpipe(stream->fd);
 
     // Enable non-blocking I/O
-    fcntl(stream->fd, F_SETFL, (long) (O_RDWR | O_NONBLOCK));
+    fcntl(stream->fd, F_SETFL, O_RDWR | O_NONBLOCK);
 
     loginetadr(info, "connection established", sa, client_address.sin_port);
 
@@ -632,10 +632,10 @@ application code does not crash during writes to a broken pipe.
       stream->type = BUFIO_PIPE;  // TODO: Restructure code
       if (stream->mode & O_WRONLY) {
         stream->fd = STDOUT_FILENO;  // Write-only
-        fcntl(stream->fd, F_SETFL, (long)(O_WRONLY | O_NONBLOCK));
+        fcntl(stream->fd, F_SETFL, O_WRONLY | O_NONBLOCK);
       } else if ((stream->mode & O_RDWR) == 0) {
         stream->fd = STDIN_FILENO;  // Read-only
-        fcntl(stream->fd, F_SETFL, (long)(O_NONBLOCK));
+        fcntl(stream->fd, F_SETFL, O_NONBLOCK);
       } else {
         // Read/write
         log2string(info, "invalid mode", opt, "for standard stream");
@@ -793,7 +793,7 @@ application code does not crash during writes to a broken pipe.
   }
 
   // Enable non-blocking I/O
-  fcntl(stream->fd, F_SETFL, (long) (O_RDWR | O_NONBLOCK));
+  fcntl(stream->fd, F_SETFL, O_RDWR | O_NONBLOCK);
 
   if (bufio_set_buffer(stream, bufsize > 0 ? bufsize : BUFIO_BUFSIZE) != 0) {
     logstring(info, "can not create buffer");
@@ -943,6 +943,7 @@ and the status code of the stream was set.
     if (nbytes == 0 &&
         ((poll_in.revents & POLLIN) || stream->type == BUFIO_FIFO)) {
       // Reached end-of-file
+      debug_print("eof with %zu remaining bytes (%zu bytes requested)", remaining_bytes, size);
       stream->status = BUFIO_EOF;
       bufio_release_read_lock(stream);
       return size - remaining_bytes;

--- a/tests/bufio_test_namedpipe.c
+++ b/tests/bufio_test_namedpipe.c
@@ -1,0 +1,57 @@
+#ifdef __linux__
+#define _DEFAULT_SOURCE
+#define _BSD_SOURCE
+#define _POSIX_C_SOURCE 200809L
+#else
+#undef _POSIX_C_SOURCE
+#endif
+
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <sys/time.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+#include "bufio.h"
+#include "test.h"
+
+
+int main(void)
+{
+  char buf[16];
+
+  unlink("test_bufio_namedpipe.fifo");
+  assert(mkfifo("test_bufio_namedpipe.fifo", S_IRUSR | S_IWUSR) == 0);
+
+  // Attempt to open a writer: this should fail after the timeout because no one is listening
+  struct timeval before, after;
+  assert(gettimeofday(&before, NULL) == 0);
+  bufio_stream *so = bufio_open("test_bufio_namedpipe.fifo", "w", 1000, 256, "bufio_test_namedpipe");
+  assert(so == NULL);
+  assert(gettimeofday(&after, NULL) == 0);
+  assert(after.tv_sec + 1e-6 * after.tv_usec - before.tv_sec - 1e-6 * before.tv_usec >= 1.0);
+
+  // Open a reader
+  bufio_stream *si = bufio_open("test_bufio_namedpipe.fifo", "r", 1000, 256, "bufio_test_namedpipe");
+  assert(si != NULL);
+
+  // Open a writer: this should be much quicker than before
+  assert(gettimeofday(&before, NULL) == 0);
+  so = bufio_open("test_bufio_namedpipe.fifo", "w", 1000, 256, "bufio_test_namedpipe");
+  assert(so != NULL);
+  assert(gettimeofday(&after, NULL) == 0);
+  assert(after.tv_sec + 1e-6 * after.tv_usec - before.tv_sec - 1e-6 * before.tv_usec < 1.0);
+
+  // Assert no initial data
+  assert(bufio_read(si, buf, 16) == 0 && bufio_status(si) == BUFIO_TIMEDOUT);
+  assert(bufio_wait(si, 0) == 0 && bufio_status(si) == BUFIO_TIMEDOUT);
+  assert(bufio_wait(si, 100) == 0 && bufio_status(si) == BUFIO_TIMEDOUT);
+
+  // Clean up
+  assert(bufio_close(so) == 0);
+  assert(bufio_close(si) == 0);
+  assert(unlink("test_bufio_namedpipe.fifo") == 0);
+
+  return 0;
+}

--- a/tests/bufio_test_namedpipe.c
+++ b/tests/bufio_test_namedpipe.c
@@ -70,5 +70,7 @@ int main(void)
   assert(gettimeofday(&after, NULL) == 0);
   assert(after.tv_sec + 1e-6 * after.tv_usec - before.tv_sec - 1e-6 * before.tv_usec >= 1.0);
 
+  assert(unlink("test_bufio_namedpipe.fifo") == 0);
+
   return 0;
 }

--- a/tests/bufio_test_namedpipe.c
+++ b/tests/bufio_test_namedpipe.c
@@ -63,9 +63,12 @@ int main(void)
   assert(si != NULL);
 
   // Assert no initial data and timeout (not EOF, even when there's no writer)
-  assert(bufio_read(si, buf, 16) == 0 && bufio_status(si) == BUFIO_TIMEDOUT);
-  assert(bufio_wait(si, 0) == 0 && bufio_status(si) == BUFIO_TIMEDOUT);
-  assert(bufio_wait(si, 100) == 0 && bufio_status(si) == BUFIO_TIMEDOUT);
+  assert(bufio_read(si, buf, 16) == 0 && bufio_status(si) == BUFIO_EOF);
+  assert(bufio_wait(si, 0) == 0 && bufio_status(si) == BUFIO_EOF);
+  assert(gettimeofday(&before, NULL) == 0);
+  assert(bufio_wait(si, 1000) == 0 && bufio_status(si) == BUFIO_EOF);
+  assert(gettimeofday(&after, NULL) == 0);
+  assert(after.tv_sec + 1e-6 * after.tv_usec - before.tv_sec - 1e-6 * before.tv_usec >= 1.0);
 
   return 0;
 }

--- a/tests/bufio_test_namedpipe.c
+++ b/tests/bufio_test_namedpipe.c
@@ -62,7 +62,7 @@ int main(void)
   si = bufio_open("test_bufio_namedpipe.fifo", "r", 1000, 256, "bufio_test_namedpipe");
   assert(si != NULL);
 
-  // Assert no initial data and timeout (not EOF, even when there's no writer)
+  // Assert no initial data and EOF (when there's no writer)
   assert(bufio_read(si, buf, 16) == 0 && bufio_status(si) == BUFIO_EOF);
   assert(bufio_wait(si, 0) == 0 && bufio_status(si) == BUFIO_EOF);
   assert(gettimeofday(&before, NULL) == 0);

--- a/tests/bufio_test_namedpipe_async.c
+++ b/tests/bufio_test_namedpipe_async.c
@@ -1,0 +1,61 @@
+#ifdef __linux__
+#define _DEFAULT_SOURCE
+#define _BSD_SOURCE
+#define _POSIX_C_SOURCE 200809L
+#else
+#undef _POSIX_C_SOURCE
+#endif
+
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <sys/time.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+#include "bufio.h"
+#include "test.h"
+
+
+int main(void)
+{
+  char buf[16];
+
+  unlink("test_bufio_namedpipe.fifo");
+  assert(mkfifo("test_bufio_namedpipe.fifo", S_IRUSR | S_IWUSR) == 0);
+
+  FORK_CHILD
+    // Open a reader
+    bufio_stream *si = bufio_open("test_bufio_namedpipe.fifo", "r", 1000, 256, "bufio_test_namedpipe");
+    assert(si != NULL);
+
+    // Wait until writer is connected
+    bufio_timeout(si, 1000);
+    size_t nread = 0;
+    while ((nread = bufio_read(si, buf, 16)) == 0)
+        assert(bufio_status(si) == BUFIO_EOF);
+
+    assert(nread == 16);
+
+    // Clean up
+    assert(bufio_close(si) == 0);
+
+  FORK_PARENT
+    // Open a writer - this waits until a reader is present
+    bufio_stream *so = bufio_open("test_bufio_namedpipe.fifo", "w", 2000, 256, "bufio_test_namedpipe");
+    assert(so != NULL);
+
+    // Delay a bit such that bufio_read enters poll()
+    usleep(100000);
+
+    // Write something
+    assert(bufio_write(so, buf, 16) == 16 && bufio_flush(so) == 0);
+
+    // Clean up
+    assert(bufio_close(so) == 0);
+
+  FORK_JOIN
+
+  assert(unlink("test_bufio_namedpipe.fifo") == 0);
+  return 0;
+}

--- a/tests/bufio_test_pipe.c
+++ b/tests/bufio_test_pipe.c
@@ -50,12 +50,12 @@ int main(void)
 
     // Assert EOF after writer hung up
     struct timeval before, after;
-    assert(bufio_read(si, buf, 16) == 0 && bufio_status(si) == BUFIO_EOF);
-    assert(bufio_wait(si, 0) == 0 && bufio_status(si) == BUFIO_EOF);
+    assert(bufio_read(si, buf, 16) == 0 && bufio_status(si) == BUFIO_EPIPE);
+    assert(bufio_wait(si, 0) == -1 && bufio_status(si) == BUFIO_EPIPE);
     assert(gettimeofday(&before, NULL) == 0);
-    assert(bufio_wait(si, 1000) == 0 && bufio_status(si) == BUFIO_EOF);
+    assert(bufio_wait(si, 1000) == -1 && bufio_status(si) == BUFIO_EPIPE);
     assert(gettimeofday(&after, NULL) == 0);
-    assert(after.tv_sec + 1e-6 * after.tv_usec - before.tv_sec - 1e-6 * before.tv_usec >= 1.0);
+    assert(after.tv_sec + 1e-6 * after.tv_usec - before.tv_sec - 1e-6 * before.tv_usec < 1.0);
 
     assert(bufio_close(si) == 0);
 

--- a/tests/bufio_test_pipe.c
+++ b/tests/bufio_test_pipe.c
@@ -1,0 +1,82 @@
+#ifdef __linux__
+#define _DEFAULT_SOURCE
+#define _BSD_SOURCE
+#define _POSIX_C_SOURCE 200809L
+#else
+#undef _POSIX_C_SOURCE
+#endif
+
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <sys/time.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+#include "bufio.h"
+#include "test.h"
+
+
+int main(void)
+{
+  char buf[16];
+
+  // Create pipe
+  int p[2];
+  assert(pipe(p) == 0);
+  assert(close(STDIN_FILENO) == 0);
+  assert(close(STDOUT_FILENO) == 0);
+
+  FORK_CHILD
+    // Redirect pipe to stdin
+    assert(close(p[1]) == 0);
+    assert(dup2(p[0], STDIN_FILENO) == STDIN_FILENO);
+
+    // Open a reader on stdin
+    bufio_stream *si = bufio_open("-", "r", 100, 256, "bufio_test_pipe");
+    assert(si != NULL);
+
+    // Assert no initial data
+    assert(bufio_read(si, buf, 16) == 0 && bufio_status(si) == BUFIO_TIMEDOUT);
+    assert(bufio_wait(si, 0) == 0 && bufio_status(si) == BUFIO_TIMEDOUT);
+    assert(bufio_wait(si, 100) == 0 && bufio_status(si) == BUFIO_TIMEDOUT);
+
+    sleep(1);
+
+    // Test read after write
+    assert(bufio_read(si, buf, 4) == 4);
+
+    sleep(2);
+
+    // Assert EOF after writer hung up
+    struct timeval before, after;
+    assert(bufio_read(si, buf, 16) == 0 && bufio_status(si) == BUFIO_EOF);
+    assert(bufio_wait(si, 0) == 0 && bufio_status(si) == BUFIO_EOF);
+    assert(gettimeofday(&before, NULL) == 0);
+    assert(bufio_wait(si, 1000) == 0 && bufio_status(si) == BUFIO_EOF);
+    assert(gettimeofday(&after, NULL) == 0);
+    assert(after.tv_sec + 1e-6 * after.tv_usec - before.tv_sec - 1e-6 * before.tv_usec >= 1.0);
+
+    assert(bufio_close(si) == 0);
+
+  FORK_PARENT
+    // Redirect stdout to pipe
+    assert(close(p[0]) == 0);
+    assert(dup2(p[1], STDOUT_FILENO) == STDOUT_FILENO);
+
+    // Open a writer to stdout
+    bufio_stream *so = bufio_open("-", "w", 100, 256, "bufio_test_pipe");
+    assert(so != NULL);
+
+    // Test read after write
+    sleep(1);
+    assert(bufio_write(so, buf, 4) == 4 && bufio_flush(so) == 0);
+
+    // Close writer (and the duplicate fd)
+    sleep(1);
+    assert(bufio_close(so) == 0);
+    close(p[1]);
+
+  FORK_JOIN
+  return 0;
+}

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -4,6 +4,7 @@ bufio_test_tcp_connect = executable('bufio_test_tcp_connect', 'bufio_test_tcp_co
 bufio_test_delayed_tcp_connect = executable('bufio_test_delayed_tcp_connect', 'bufio_test_delayed_tcp_connect.c', include_directories : bufio_inc, link_with : bufio_lib)
 bufio_test_lockedfile = executable('bufio_test_lockedfile', 'bufio_test_lockedfile.c', include_directories : bufio_inc, link_with : bufio_lib)
 bufio_test_file = executable('bufio_test_file', 'bufio_test_file.c', include_directories : bufio_inc, link_with : bufio_lib)
+bufio_test_pipe = executable('bufio_test_pipe', 'bufio_test_pipe.c', include_directories : bufio_inc, link_with : bufio_lib)
 bufio_test_namedpipe = executable('bufio_test_namedpipe', 'bufio_test_namedpipe.c', include_directories : bufio_inc, link_with : bufio_lib)
 bufio_test_wait_on_tcpclose_with_pending_data = executable('bufio_test_wait_on_tcpclose_with_pending_data', 'bufio_test_wait_on_tcpclose_with_pending_data.c', include_directories : bufio_inc, link_with : bufio_lib)
 bufio_test_wait_on_tcpclose = executable('bufio_test_wait_on_tcpclose', 'bufio_test_wait_on_tcpclose.c', include_directories : bufio_inc, link_with : bufio_lib)
@@ -15,6 +16,7 @@ test('bufio_test_tcp_connect', bufio_test_tcp_connect, is_parallel : false, suit
 test('bufio_test_delayed_tcp_connect', bufio_test_delayed_tcp_connect, is_parallel : false, suite: ['all', 'default'])
 test('bufio_test_lockedfile', bufio_test_lockedfile, is_parallel : false, suite: ['all', 'default'])
 test('bufio_test_file', bufio_test_file, is_parallel : false, suite: ['all', 'default'])
+test('bufio_test_pipe', bufio_test_pipe, is_parallel : false, suite: ['all', 'default'])
 test('bufio_test_namedpipe', bufio_test_namedpipe, is_parallel : false, suite: ['all', 'default'])
 test('bufio_test_mem_interface', bufio_test_mem_interface, is_parallel : false, suite: ['all', 'default'])
 

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -6,6 +6,7 @@ bufio_test_lockedfile = executable('bufio_test_lockedfile', 'bufio_test_lockedfi
 bufio_test_file = executable('bufio_test_file', 'bufio_test_file.c', include_directories : bufio_inc, link_with : bufio_lib)
 bufio_test_pipe = executable('bufio_test_pipe', 'bufio_test_pipe.c', include_directories : bufio_inc, link_with : bufio_lib)
 bufio_test_namedpipe = executable('bufio_test_namedpipe', 'bufio_test_namedpipe.c', include_directories : bufio_inc, link_with : bufio_lib)
+bufio_test_namedpipe_async = executable('bufio_test_namedpipe_async', 'bufio_test_namedpipe_async.c', include_directories : bufio_inc, link_with : bufio_lib)
 bufio_test_wait_on_tcpclose_with_pending_data = executable('bufio_test_wait_on_tcpclose_with_pending_data', 'bufio_test_wait_on_tcpclose_with_pending_data.c', include_directories : bufio_inc, link_with : bufio_lib)
 bufio_test_wait_on_tcpclose = executable('bufio_test_wait_on_tcpclose', 'bufio_test_wait_on_tcpclose.c', include_directories : bufio_inc, link_with : bufio_lib)
 bufio_test_mem_interface = executable('bufio_test_mem_interface', 'bufio_test_mem_interface.c', include_directories : bufio_inc, link_with : bufio_lib)
@@ -18,6 +19,7 @@ test('bufio_test_lockedfile', bufio_test_lockedfile, is_parallel : false, suite:
 test('bufio_test_file', bufio_test_file, is_parallel : false, suite: ['all', 'default'])
 test('bufio_test_pipe', bufio_test_pipe, is_parallel : false, suite: ['all', 'default'])
 test('bufio_test_namedpipe', bufio_test_namedpipe, is_parallel : false, suite: ['all', 'default'])
+test('bufio_test_namedpipe_async', bufio_test_namedpipe_async, is_parallel : false, suite: ['all', 'default'])
 test('bufio_test_mem_interface', bufio_test_mem_interface, is_parallel : false, suite: ['all', 'default'])
 
 test('bufio_test_wait_on_tcpclose', bufio_test_wait_on_tcpclose, is_parallel : false, timeout : 120, suite: ['all', 'extensive'])

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -4,6 +4,7 @@ bufio_test_tcp_connect = executable('bufio_test_tcp_connect', 'bufio_test_tcp_co
 bufio_test_delayed_tcp_connect = executable('bufio_test_delayed_tcp_connect', 'bufio_test_delayed_tcp_connect.c', include_directories : bufio_inc, link_with : bufio_lib)
 bufio_test_lockedfile = executable('bufio_test_lockedfile', 'bufio_test_lockedfile.c', include_directories : bufio_inc, link_with : bufio_lib)
 bufio_test_file = executable('bufio_test_file', 'bufio_test_file.c', include_directories : bufio_inc, link_with : bufio_lib)
+bufio_test_namedpipe = executable('bufio_test_namedpipe', 'bufio_test_namedpipe.c', include_directories : bufio_inc, link_with : bufio_lib)
 bufio_test_wait_on_tcpclose_with_pending_data = executable('bufio_test_wait_on_tcpclose_with_pending_data', 'bufio_test_wait_on_tcpclose_with_pending_data.c', include_directories : bufio_inc, link_with : bufio_lib)
 bufio_test_wait_on_tcpclose = executable('bufio_test_wait_on_tcpclose', 'bufio_test_wait_on_tcpclose.c', include_directories : bufio_inc, link_with : bufio_lib)
 bufio_test_mem_interface = executable('bufio_test_mem_interface', 'bufio_test_mem_interface.c', include_directories : bufio_inc, link_with : bufio_lib)
@@ -14,6 +15,7 @@ test('bufio_test_tcp_connect', bufio_test_tcp_connect, is_parallel : false, suit
 test('bufio_test_delayed_tcp_connect', bufio_test_delayed_tcp_connect, is_parallel : false, suite: ['all', 'default'])
 test('bufio_test_lockedfile', bufio_test_lockedfile, is_parallel : false, suite: ['all', 'default'])
 test('bufio_test_file', bufio_test_file, is_parallel : false, suite: ['all', 'default'])
+test('bufio_test_namedpipe', bufio_test_namedpipe, is_parallel : false, suite: ['all', 'default'])
 test('bufio_test_mem_interface', bufio_test_mem_interface, is_parallel : false, suite: ['all', 'default'])
 
 test('bufio_test_wait_on_tcpclose', bufio_test_wait_on_tcpclose, is_parallel : false, timeout : 120, suite: ['all', 'extensive'])


### PR DESCRIPTION
This PR attempts to add explicit tests for named pipes.

Two issues have been identified so far:
1. Opening a named pipe in write mode should wait for a writer to attach until the timeout is reached. This has been fixed in 34a81d8902a15e8a9913acf5295ed0dd8f9cf2aa.
2. Reading or waiting on a named pipe that has no writer attached should consistently return EOF. This is currently not the case for `bufio_read`, see the test added in 271899e19babb6b4d0d8d65920149fd9c1a3a441.