### PR TITLE
Adjust return behaviour on partial read/writes in mem:// interface.

### DIFF
--- a/src/bufio.c
+++ b/src/bufio.c
@@ -837,9 +837,8 @@ and the status code of the stream was set.
 
     size_t readable_bytes = stream->mem_size - stream->mem_offset;
     size_t bytes_to_read = size < readable_bytes ? size : readable_bytes;
-    if (bytes_to_read == 0) {
+    if (bytes_to_read < size) {
       stream->status = BUFIO_EOF;
-      return 0;
     }
 
     bufio_memcpy(ptr, stream->mem_addr + stream->mem_offset, bytes_to_read);
@@ -981,6 +980,8 @@ error has occured and the status code of the stream was set.
 
   BUFIO_TIMEDOUT A write operation or poll timed out.
 
+  BUFIO_EOF      Reached end-of-file.
+
   BUFIO_EPIPE    The device or socket has been disconnected or an exceptional
                  condition such as a low-level I/O error has occurred on the
                  device or socket.
@@ -1006,9 +1007,8 @@ error has occured and the status code of the stream was set.
 
     size_t writable_bytes = stream->mem_size - stream->mem_offset;
     size_t bytes_to_write = size < writable_bytes ? size : writable_bytes;
-    if (bytes_to_write == 0) {
+    if (bytes_to_write < size) {
       stream->status = BUFIO_EOF;
-      return 0;
     }
 
     bufio_memcpy(stream->mem_addr + stream->mem_offset, ptr, bytes_to_write);

--- a/src/bufio.c
+++ b/src/bufio.c
@@ -838,6 +838,7 @@ and the status code of the stream was set.
     size_t readable_bytes = stream->mem_size - stream->mem_offset;
     size_t bytes_to_read = size < readable_bytes ? size : readable_bytes;
     if (bytes_to_read < size) {
+      debug_print("reading %zu bytes, but %zu were requested", bytes_to_read, size);
       stream->status = BUFIO_EOF;
     }
 
@@ -980,7 +981,7 @@ error has occured and the status code of the stream was set.
 
   BUFIO_TIMEDOUT A write operation or poll timed out.
 
-  BUFIO_EOF      Reached end-of-file.
+  BUFIO_NOSPACE  Not enough space available to complete write operation.
 
   BUFIO_EPIPE    The device or socket has been disconnected or an exceptional
                  condition such as a low-level I/O error has occurred on the
@@ -1008,7 +1009,8 @@ error has occured and the status code of the stream was set.
     size_t writable_bytes = stream->mem_size - stream->mem_offset;
     size_t bytes_to_write = size < writable_bytes ? size : writable_bytes;
     if (bytes_to_write < size) {
-      stream->status = BUFIO_EOF;
+      debug_print("writing %zu bytes, but %zu were requested", bytes_to_write, size);
+      stream->status = BUFIO_NOSPACE;
     }
 
     bufio_memcpy(stream->mem_addr + stream->mem_offset, ptr, bytes_to_write);
@@ -1557,6 +1559,7 @@ Returns the status of stream.
 BUFIO_OKAY (0) No error
 BUFIO_TIMEDOUT Poll or I/O operation timed out
 BUFIO_EOF      Reached end-of-file
+BUFIO_NOSPACE  Not enough space available to complete write operation.
 BUFIO_EPIPE    I/O error occured
 
 //----------------------------------------------------------------------------*/
@@ -1586,6 +1589,7 @@ Returns a description of the status of stream.
     case BUFIO_OKAY:     return "okay";
     case BUFIO_TIMEDOUT: return "timeout";
     case BUFIO_EOF:      return "end-of-file";
+    case BUFIO_NOSPACE:  return "no space available";
     default:             return "unknown error";
   }
 }

--- a/src/bufio.h
+++ b/src/bufio.h
@@ -38,7 +38,8 @@ typedef enum {
   BUFIO_EPIPE = -1,    // Device or socket has been disconnected or an I/O error occured
   BUFIO_OKAY = 0,      // Success
   BUFIO_TIMEDOUT = 1,  // Poll or I/O operation timed out
-  BUFIO_EOF = 2        // Reached end-of-file
+  BUFIO_EOF = 2,       // Reached end-of-file
+  BUFIO_NOSPACE = 3    // Not enough space available for write operation. Only returned when writing to mem:// (so far)
 } bufio_stream_status;
 
 typedef struct {

--- a/tests/bufio_test_mem_interface.c
+++ b/tests/bufio_test_mem_interface.c
@@ -82,6 +82,18 @@ int main(void) {
   bufio_set_mem_field(bfs, mem_buf, BUF_SIZE);
   assert(bufio_close(bfs) == 0);
 
+  bfs = bufio_open("mem://0/0","w",0, 0, "bufio_test_mem_interface");
+  bufio_set_mem_field(bfs, mem_buf, 2);
+  assert(bufio_write(bfs, write_buf, 4) == 2);
+  assert(bufio_status(bfs) == BUFIO_NOSPACE);
+  assert(bufio_close(bfs) == 0);
+
+  bfs = bufio_open("mem://0/0","r",0, 0, "bufio_test_mem_interface");
+  bufio_set_mem_field(bfs, mem_buf, 2);
+  assert(bufio_read(bfs, read_buf, 4) == 2);
+  assert(bufio_status(bfs) == BUFIO_EOF);
+  assert(bufio_close(bfs) == 0);
+
   free(mem_string);
 
   return 0;


### PR DESCRIPTION
Previously BUFIO_EOF would be set only on 0 byte read/write calls. if `bytes_to_read` or `bytes_to_write` would be less then `size` the function would return `< size` bytes without the correct bufio status.

This would lock-up an FCIO stream e.g. if only 2 bytes would be available to read, when the stream would expect a tag (4 bytes).

Please confirm my thinking, that this would be in line with the non `mem://` behaviour, or at least close enough.
`bufio_write` did not previously set `BUFIO_EOF`.